### PR TITLE
Kotlin usage improvements:

### DIFF
--- a/src/androidTest/java/com/f2prateek/bee/MainActivityTest.kt
+++ b/src/androidTest/java/com/f2prateek/bee/MainActivityTest.kt
@@ -6,7 +6,6 @@ import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
-import com.f2prateek.bee.Matchers.Companion.childWithText
 import com.squareup.spoon.Spoon
 import org.junit.BeforeClass
 import org.junit.Rule

--- a/src/androidTest/java/com/f2prateek/bee/Matchers.kt
+++ b/src/androidTest/java/com/f2prateek/bee/Matchers.kt
@@ -7,47 +7,34 @@ import android.widget.TextView
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 
-class Matchers private constructor() {
-    init {
-        throw AssertionError("no instances.")
-    }
-
-    companion object {
-        /** Matches that a [ViewGroup] contains a child [TextView] with the given text. */
-        fun childWithText(text: String): Matcher<View> {
-            val matcher = org.hamcrest.Matchers.`is`(text)
-            return childWithMatcher(object : BoundedMatcher<View, TextView>(TextView::class.java) {
-                override fun describeTo(description: Description) {
-                    description.appendText("with text: ")
-                    matcher.describeTo(description)
-                }
-
-                override fun matchesSafely(textView: TextView): Boolean {
-                    return matcher.matches(textView.text)
-                }
-            })
+/** Matches that a [ViewGroup] contains a child [TextView] with the given text. */
+fun childWithText(text: String): Matcher<View> {
+    val matcher = org.hamcrest.Matchers.`is`(text)
+    return childWithMatcher(object : BoundedMatcher<View, TextView>(TextView::class.java) {
+        override fun describeTo(description: Description) {
+            description.appendText("with text: ")
+            matcher.describeTo(description)
         }
 
-        /**
-         * Matches that a [ViewGroup] contains a child [View] that matches the given
-         * `matcher`.
-         */
-        private fun childWithMatcher(matcher: Matcher<*>): Matcher<View> {
-            return object : BoundedMatcher<View, ViewGroup>(ViewGroup::class.java) {
-                override fun describeTo(description: Description) {
-                    description.appendText("child with matcher: ")
-                    matcher.describeTo(description)
-                }
+        override fun matchesSafely(textView: TextView): Boolean {
+            return matcher.matches(textView.text)
+        }
+    })
+}
 
-                public override fun matchesSafely(viewGroup: ViewGroup): Boolean {
-                    for (i in 0..viewGroup.childCount - 1) {
-                        if (matcher.matches(viewGroup.getChildAt(i))) {
-                            return true
-                        }
-                    }
-                    return false
-                }
-            }
+/**
+ * Matches that a [ViewGroup] contains a child [View] that matches the given
+ * `matcher`.
+ */
+private fun childWithMatcher(matcher: Matcher<*>): Matcher<View> {
+    return object : BoundedMatcher<View, ViewGroup>(ViewGroup::class.java) {
+        override fun describeTo(description: Description) {
+            description.appendText("child with matcher: ")
+            matcher.describeTo(description)
+        }
+
+        public override fun matchesSafely(viewGroup: ViewGroup): Boolean {
+            return (0 until viewGroup.childCount).any { matcher.matches(viewGroup.getChildAt(it)) }
         }
     }
 }


### PR DESCRIPTION
1. Pull matcher utilities out of companion objects.
2. Use `any` and `until` instead of hand rolled for loop.